### PR TITLE
fix build: include <functional> for std::function

### DIFF
--- a/src/ui/Button.h
+++ b/src/ui/Button.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <algorithm>
+#include <functional>
 #include "Window.h"
 #include "UTF8.h"
 #include "View.h"


### PR DESCRIPTION
tested on gcc version 12.3.0 (GCC) on NixOS

    src/ui/Button.h:161:10: error: ‘function’ in namespace ‘std’ does not name a template type
      161 |     std::function<void(Button&)> _action;
          |          ^~~~~~~~
    src/ui/Button.h:1:1: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
      +++ |+#include <functional>
        1 | #pragma once