### PR TITLE
use https url for Toastbox submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/toastbox"]
 	path = lib/toastbox
-	url = git@github.com:toasterllc/Toastbox.git
+	url = https://github.com/toasterllc/Toastbox.git


### PR DESCRIPTION
This allows fetching the submodule on machines with no github account configured.