### PR TITLE
add license?

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,3 @@
+Original work in this repository is hereby placed into the public domain.
+
+Note that this repository contains unoriginal work (such as `lib/libgit2`, `lib/ncurses`, and `lib/nlohmann`) which maintains the license specified in the respective files.


### PR DESCRIPTION
I copied the format of other licenses in the toasterllc github org.

Obviously it's not my place to say how this code should be licensed, but if you add a license like this (or [any other](https://choosealicense.com/) common license) it would make it easier for me and other people to use this software.